### PR TITLE
fixes the URL for serverless.com

### DIFF
--- a/lambda-api/README.md
+++ b/lambda-api/README.md
@@ -6,7 +6,7 @@ The code in this directory will deploy a Serverless application. It has a single
 
 ### Usage
 
-1. Install the [Serverless Framework](www.serverless.com):
+1. Install the [Serverless Framework](https://serverless.com):
 
 	```bash
 	npm install -g serverless


### PR DESCRIPTION
the link was pointing to 'https://github.com/alexdebrie/aws-api-performance-bakeoff/blob/master/lambda-api/www.serverless.com'